### PR TITLE
SCRUM-71: Thiết lập pipeline CI/CD kiểm thử DB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         if: failure()  # Nếu bước `mvn test` thất bại, in ra log test từ Surefire
         run: cat target/surefire-reports/*.txt || true
 
-#
+
 #  deploy:
 #    needs: test  # Chỉ chạy job deploy nếu job test thành công
 #    runs-on: ubuntu-latest
@@ -66,4 +66,4 @@ jobs:
 #          ssh-keyscan -H $REMOTE_HOST >> ~/.ssh/known_hosts  # Lưu fingerprint của server vào danh sách trusted
 #          scp target/*.jar $REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR  # Copy file JAR lên server
 #          ssh $REMOTE_USER@$REMOTE_HOST "sudo systemctl restart your-spring-boot-service"  # Restart service trên server
-#
+


### PR DESCRIPTION
Thiết lập GitHub Actions để chạy kiểm thử tự động sau mỗi lần push code.
Bao gồm cấu hình cơ bản cho kiểm thử DB liên quan đến SCRUM-71.A